### PR TITLE
Update libpreludecpp-python.i to build with SWIG 4

### DIFF
--- a/bindings/python/libpreludecpp-python.i
+++ b/bindings/python/libpreludecpp-python.i
@@ -40,7 +40,7 @@
 %feature("python:slot", "tp_repr", functype="reprfunc") *::toString;
 %feature("python:slot", "mp_subscript", functype="binaryfunc") *::get;
 %feature("python:slot", "mp_ass_subscript", functype="objobjargproc") *::set;
-%feature("python:slot", "tp_hash") Prelude::IDMEFValue::getType;
+%feature("python:slot", "tp_hash", functype="hashfunc") Prelude::IDMEFValue::getType;
 
 /*
  * IDMEFClass


### PR DESCRIPTION
Update the file to be able to build with SWIG 4. 
For more details look here https://sourceforge.net/p/swig/mailman/message/36603516/
The changes also work for SWIG 3.0.12